### PR TITLE
add plantuml activity diagram (new syntax) to templates

### DIFF
--- a/src/templates.ts
+++ b/src/templates.ts
@@ -65,6 +65,14 @@ const templates: Template[] = [
         Bob -> Alice : Authentication Request
         Bob <- Alice : Authentication Response
         @enduml`)),
+    new InMemoryTemplate("plantuml", "PlantUML Activity Diagram (new)", dedent(`
+        @startuml
+        start
+        :Hello world;
+        :This is defined on
+        several **lines**;
+        stop
+        @enduml`)),
     new InMemoryTemplate("plantuml", "PlantUML C4 Container Diagram", dedent(`
         @startuml
         !include https://raw.githubusercontent.com/plantuml-stdlib/C4-PlantUML/master/C4_Container.puml
@@ -158,3 +166,4 @@ const templates: Template[] = [
 
 
 export default templates;
+


### PR DESCRIPTION
Hi @npgrosser, thanks for the great plugin. 
I was missing a template for the plantuml activity diagram, thus thinking it was not supported. It actually is supported by kroki :-) Would be nice to have it in the official plugin.